### PR TITLE
fix: 组件页 Page title 统一为大驼峰

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/modules-dev",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "用于辅助在项目内启动一个规范化组件开发的环境",
   "publishConfig": {
     "access": "public",

--- a/src/ExamplePage.js
+++ b/src/ExamplePage.js
@@ -6,6 +6,7 @@ import style from './example.module.scss';
 import classnames from 'classnames';
 import ExampleDriver from '@kne/example-driver';
 import {createWithRemoteLoader} from '@kne/remote-loader';
+import camelCase from '@kne/camel-case';
 import Highlight from './Highlight';
 import ExampleDriverContext from './ExampleDriverContext';
 
@@ -69,7 +70,7 @@ const ExamplePage = createWithRemoteLoader({
     modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext"]
 })(({remoteModules, data, current, menuProps = {}, items, pageProps = {}}) => {
     const [Page, Menu] = remoteModules;
-    return <Page title={data.name} className={style['example-page']}
+    return <Page title={camelCase(data.name || '')} className={style['example-page']}
                  menu={items && items.length > 0 &&
                      <Menu {...menuProps} currentKey={current} items={items}/>} {...pageProps}>
         <ExampleContent data={data}/>


### PR DESCRIPTION
展示名经 camel-case 转换，避免 kebab-case 等原始目录名直接出现在标题。