### PR TITLE
fix: 切换组件时页面滚动到顶部

### DIFF
--- a/src/ExamplePage.js
+++ b/src/ExamplePage.js
@@ -70,6 +70,22 @@ const ExamplePage = createWithRemoteLoader({
     modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext"]
 })(({remoteModules, data, current, menuProps = {}, items, pageProps = {}}) => {
     const [Page, Menu] = remoteModules;
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+        const mainContent = document.querySelector('.core-page-main-content');
+        if (!mainContent) {
+            return;
+        }
+        let el = mainContent;
+        while (el && el !== document.body) {
+            if (el.scrollTop) {
+                el.scrollTop = 0;
+            }
+            el = el.parentElement;
+        }
+    }, [current]);
+
     return <Page title={camelCase(data.name || '')} className={style['example-page']}
                  menu={items && items.length > 0 &&
                      <Menu {...menuProps} currentKey={current} items={items}/>} {...pageProps}>

--- a/src/ExamplePage.js
+++ b/src/ExamplePage.js
@@ -67,24 +67,16 @@ export const ExampleContent = createWithRemoteLoader({
 });
 
 const ExamplePage = createWithRemoteLoader({
-    modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext"]
+    modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext", "components-core:Common@getScrollEl"]
 })(({remoteModules, data, current, menuProps = {}, items, pageProps = {}}) => {
-    const [Page, Menu] = remoteModules;
+    const [Page, Menu, , getScrollEl] = remoteModules;
 
     useEffect(() => {
-        window.scrollTo(0, 0);
-        const mainContent = document.querySelector('.core-page-main-content');
-        if (!mainContent) {
-            return;
+        const scrollEl = getScrollEl();
+        if (scrollEl) {
+            scrollEl.scrollTop = 0;
         }
-        let el = mainContent;
-        while (el && el !== document.body) {
-            if (el.scrollTop) {
-                el.scrollTop = 0;
-            }
-            el = el.parentElement;
-        }
-    }, [current]);
+    }, [current, getScrollEl]);
 
     return <Page title={camelCase(data.name || '')} className={style['example-page']}
                  menu={items && items.length > 0 &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 切换组件时通过 `components-core:Common@getScrollEl` 获取滚动容器并将 `scrollTop` 置为 0
- 不再手动查询 DOM / 向上遍历父级

## Test plan
- [ ] 打开 modules-dev 组件页，滚动到页面中下部
- [ ] 通过左侧菜单切换到另一个组件
- [ ] 确认页面内容回到顶部
- [ ] 连续切换多个组件，确认每次都会滚回顶部

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ad3c20-5435-48d0-8bdc-c223e806f7da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ad3c20-5435-48d0-8bdc-c223e806f7da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

