### PR TITLE
fix: 用 useScrollElement 修复切换组件滚顶

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/modules-dev",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "用于辅助在项目内启动一个规范化组件开发的环境",
   "publishConfig": {
     "access": "public",

--- a/src/Example.js
+++ b/src/Example.js
@@ -1,8 +1,27 @@
-import React from 'react';
+import React, {useLayoutEffect} from 'react';
 import {useParams, Navigate, useSearchParams} from "react-router-dom";
 import ExamplePage from './ExamplePage';
 import ensureSlash from '@kne/ensure-slash';
 import Fetch from '@kne/react-fetch';
+import {createWithRemoteLoader} from '@kne/remote-loader';
+
+const ScrollToTop = createWithRemoteLoader({
+    modules: ['components-core:Global@useScrollElement']
+})(({remoteModules, watch}) => {
+    const [useScrollElement] = remoteModules;
+    const getScrollElement = useScrollElement();
+
+    useLayoutEffect(() => {
+        const scrollEl = getScrollElement();
+        if (scrollEl) {
+            scrollEl.scrollTo(0, 0);
+        }
+        // body 上存在 overflow: auto !important 时，实际滚动可能在 document
+        window.scrollTo(0, 0);
+    }, [watch, getScrollElement]);
+
+    return null;
+});
 
 const Example = ({baseUrl, readme, pageProps}) => {
     const {id: current} = useParams();
@@ -23,11 +42,12 @@ const Example = ({baseUrl, readme, pageProps}) => {
                                                            };
                                                        })}/>
 
-    if (data && data.hasOwnProperty('loader') || data.hasOwnProperty('url')) {
-        return <Fetch {...Object.assign({}, data)} render={renderExamplePage}/>
-    }
-
-    return renderExamplePage({data});
+    return <>
+        <ScrollToTop watch={current} remoteFallback={null}/>
+        {(data && data.hasOwnProperty('loader') || data.hasOwnProperty('url')) ?
+            <Fetch {...Object.assign({}, data)} render={renderExamplePage}/> :
+            renderExamplePage({data})}
+    </>;
 };
 
 export default Example;

--- a/src/ExamplePage.js
+++ b/src/ExamplePage.js
@@ -67,17 +67,9 @@ export const ExampleContent = createWithRemoteLoader({
 });
 
 const ExamplePage = createWithRemoteLoader({
-    modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext", "components-core:Common@getScrollEl"]
+    modules: ["components-core:Layout@Page", "components-core:Layout@Menu", "components-core:Global@useGlobalContext"]
 })(({remoteModules, data, current, menuProps = {}, items, pageProps = {}}) => {
-    const [Page, Menu, , getScrollEl] = remoteModules;
-
-    useEffect(() => {
-        const scrollEl = getScrollEl();
-        if (scrollEl) {
-            scrollEl.scrollTop = 0;
-        }
-    }, [current, getScrollEl]);
-
+    const [Page, Menu] = remoteModules;
     return <Page title={camelCase(data.name || '')} className={style['example-page']}
                  menu={items && items.length > 0 &&
                      <Menu {...menuProps} currentKey={current} items={items}/>} {...pageProps}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 切换组件时使用 `components-core:Global@useScrollElement` 获取滚动根并 `scrollTo(0, 0)`
- 在路由 `id` 变化时立即滚顶（不依赖 ExamplePage / Fetch 是否已渲染）
- 同时 `window.scrollTo(0, 0)`，避免 body `overflow: auto` 导致只重置 SimpleBar 包装层无效
- 版本：`2.4.6` → `2.4.7`

## Test plan
- [ ] 打开 modules-dev 组件页，滚动到中下部
- [ ] 左侧菜单切换组件，确认回到顶部
- [ ] 连续切换多个组件均滚回顶部

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ad3c20-5435-48d0-8bdc-c223e806f7da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ad3c20-5435-48d0-8bdc-c223e806f7da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

