### PR TITLE
fix: 将 webpack/babel cache 隔离到项目 .cache

### DIFF
--- a/lib/craco-fix-plugin.js
+++ b/lib/craco-fix-plugin.js
@@ -1,5 +1,50 @@
+const path = require('path');
 const {when} = require("@kne/craco");
 const env = require("./env");
+
+const appCacheDir = path.resolve(env.appDir, '.cache');
+
+const collectLoaderUses = (rule) => {
+    const uses = [];
+    if (rule.loader || (rule.options && !rule.use)) {
+        uses.push(rule);
+    }
+    if (Array.isArray(rule.use)) {
+        uses.push(...rule.use);
+    } else if (rule.use && typeof rule.use === 'object') {
+        uses.push(rule.use);
+    }
+    return uses;
+};
+
+const visitRules = (rules, visit) => {
+    (rules || []).forEach((rule) => {
+        if (!rule) {
+            return;
+        }
+        if (rule.oneOf) {
+            visitRules(rule.oneOf, visit);
+        }
+        visit(rule);
+    });
+};
+
+// node_modules 被软链到其它 checkout 时，不能共用 node_modules/.cache（webpack pack 记绝对路径）
+const isolateAppCache = (webpackConfig) => {
+    if (webpackConfig.cache && typeof webpackConfig.cache === 'object') {
+        webpackConfig.cache.cacheDirectory = path.join(appCacheDir, 'webpack');
+    }
+    visitRules(webpackConfig.module && webpackConfig.module.rules, (rule) => {
+        collectLoaderUses(rule).forEach((use) => {
+            if (!use || typeof use !== 'object' || !use.options) {
+                return;
+            }
+            if (String(use.loader || '').includes('babel-loader')) {
+                use.options.cacheDirectory = path.join(appCacheDir, 'babel-loader');
+            }
+        });
+    });
+};
 
 // alias 到绝对路径时，即便落在 node_modules 下，ModuleScopePlugin 仍按 src 外拦截
 const allowReadmeOutsideSrc = (webpackConfig) => {
@@ -53,6 +98,7 @@ module.exports = {
             "fs": false
         };
         allowReadmeOutsideSrc(webpackConfig);
+        isolateAppCache(webpackConfig);
         return webpackConfig;
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/modules-dev",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "用于辅助在项目内启动一个规范化组件开发的环境",
   "publishConfig": {
     "access": "public",

--- a/test/craco-fix-plugin.test.js
+++ b/test/craco-fix-plugin.test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { expect } = require('chai');
 const plugin = require('../lib/craco-fix-plugin');
 const env = require('../lib/env');
@@ -38,6 +39,35 @@ describe('craco-fix-plugin readme alias', () => {
     }];
     plugin.overrideWebpackConfig({ webpackConfig, context: { env: 'development' } });
     expect(webpackConfig.resolve.plugins[0].allowedPaths).to.include(env.readmeDir);
+  });
+});
+
+describe('craco-fix-plugin app cache isolation', () => {
+  it('应将 webpack filesystem cache 指到项目 .cache/webpack', () => {
+    const webpackConfig = createConfig(true);
+    webpackConfig.cache = { type: 'filesystem', cacheDirectory: '/tmp/shared-cache' };
+    plugin.overrideWebpackConfig({ webpackConfig, context: { env: 'development' } });
+    expect(webpackConfig.cache.cacheDirectory).to.equal(path.resolve(env.appDir, '.cache/webpack'));
+  });
+
+  it('应将 babel-loader cacheDirectory 指到项目 .cache/babel-loader', () => {
+    const webpackConfig = createConfig(true);
+    webpackConfig.module = {
+      rules: [
+        {
+          oneOf: [
+            {
+              loader: '/fake/babel-loader/lib/index.js',
+              options: { cacheDirectory: true }
+            }
+          ]
+        }
+      ]
+    };
+    plugin.overrideWebpackConfig({ webpackConfig, context: { env: 'development' } });
+    expect(webpackConfig.module.rules[0].oneOf[0].options.cacheDirectory).to.equal(
+      path.resolve(env.appDir, '.cache/babel-loader')
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- 将 webpack filesystem cache 与 babel-loader cache 从 `node_modules/.cache` 改到项目根 `.cache/`，避免 workplace 软链 `node_modules` 时复用原仓 pack（绝对路径）导致编错目录、JSX preset 报错。
- 版本：`2.4.12` → `2.4.13`

## Test plan
- [ ] `npm test`
- [ ] 原仓 `craco start` 后 cache 落在项目 `.cache/webpack`、`.cache/babel-loader`
- [ ] workplace 软链 `node_modules` 后再启动，不再编译原仓 `src` 路径


Made with [Cursor](https://cursor.com)